### PR TITLE
Make '.gitignore' file extension & highlight exclusion

### DIFF
--- a/ftdetect/gitignore.vim
+++ b/ftdetect/gitignore.vim
@@ -3,4 +3,4 @@
 " Author:       gisphm <phmfk@hotmail.com>
 " URL:          https://github.com/gisphm/vim-gitignore
 
-au BufNewFile,BufRead .gitignore set filetype=gitignore
+au BufNewFile,BufRead *.gitignore set filetype=gitignore

--- a/syntax/gitignore.vim
+++ b/syntax/gitignore.vim
@@ -14,11 +14,13 @@ syn match gitignoreComment "^#.*" contains=gitignoreTodo
 syn match gitignoreComment "\s#.*"ms=s+1 contains=gitignoreTodo
 syn match gitignoreFile "^\(#\)\@!.*\(/\)\@<!$"
 syn match gitignoreDirectory "^\(#\)\@!.*\/$"
+syn match gitignoreExclusion "^!.*"
 
 " Define the default highlighting.
 " Only used when an item doesn't have highlighting yet
 hi def link gitignoreComment Comment
 hi def link gitignoreTodo Todo
+hi def link gitignoreExclusion Conditional
 hi def link gitignoreDirectory Constant
 hi def link gitignoreFile Type
 


### PR DESCRIPTION
Some utils use gitignore syntax for their needs. For example restic use it for exclude files from backup. So it'll be useful to make '.gitignore' be file extension